### PR TITLE
feat: add tranche redeem value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@buttonwood/sdk",
-    "version": "1.0.42",
+    "version": "1.0.43",
     "description": "Typescript SDK for the Buttonwood Protocol",
     "main": "./dist/src/index.js",
     "types": "./dist/src/index.d.ts",

--- a/src/entities/bond.ts
+++ b/src/entities/bond.ts
@@ -51,7 +51,7 @@ export class Bond {
             a.index > b.index ? 1 : -1,
         );
         for (const tranche of sortedTranches) {
-            this.tranches.push(new Tranche(tranche, chainId));
+            this.tranches.push(new Tranche(tranche, this.collateral, chainId));
         }
     }
 

--- a/test/entities/bond.ts
+++ b/test/entities/bond.ts
@@ -135,7 +135,9 @@ describe('Bond', () => {
         const tranches = bond.tranches;
         for (let i = 0; i < tranches.length; i++) {
             const tranche = tranches[i];
-            expect(tranche).toEqual(new Tranche(bondData.tranches[i]));
+            expect(tranche).toEqual(
+                new Tranche(bondData.tranches[i], bond.collateral),
+            );
         }
     });
 
@@ -317,6 +319,7 @@ describe('Bond', () => {
                 addressEquals(output.currency.address, bond.collateral.address),
             ).toBeTruthy();
             expect(toBaseUnits(output).toString()).toEqual(inputAmount);
+            expect(bond.tranches[0].redeemValue(input)).toEqual(output);
         });
 
         it('Successfully gets B-tranche redemption output', () => {

--- a/test/entities/tranche.ts
+++ b/test/entities/tranche.ts
@@ -19,22 +19,30 @@ function getTrancheData(): TrancheData {
     };
 }
 
+const collateral = new Token(
+    1,
+    '0x1439b0429a3ad079c55093fbfd59a7c00c888d00',
+    9,
+    'AMPL',
+    'Ampleforth',
+);
+
 describe('Tranche', () => {
     it('Fetches tranche address', () => {
         const trancheData = getTrancheData();
-        const tranche = new Tranche(trancheData);
+        const tranche = new Tranche(trancheData, collateral);
         expect(tranche.address).toEqual(trancheData.id);
     });
 
     it('Fetches tranche ratio', () => {
         const trancheData = getTrancheData();
-        const tranche = new Tranche(trancheData);
+        const tranche = new Tranche(trancheData, collateral);
         expect(tranche.ratio).toEqual(parseInt(trancheData.ratio, 10));
     });
 
     it('Fetches tranche total collateral', () => {
         const trancheData = getTrancheData();
-        const tranche = new Tranche(trancheData);
+        const tranche = new Tranche(trancheData, collateral);
         expect(tranche.totalCollateral).toEqual(
             BigNumber.from(trancheData.totalCollateral),
         );
@@ -42,7 +50,7 @@ describe('Tranche', () => {
 
     it('Fetches tranche total supply', () => {
         const trancheData = getTrancheData();
-        const tranche = new Tranche(trancheData);
+        const tranche = new Tranche(trancheData, collateral);
         expect(tranche.totalSupply).toEqual(
             BigNumber.from(trancheData.token.totalSupply),
         );
@@ -50,7 +58,7 @@ describe('Tranche', () => {
 
     it('Fetches tranche decimals', () => {
         const trancheData = getTrancheData();
-        const tranche = new Tranche(trancheData);
+        const tranche = new Tranche(trancheData, collateral);
         expect(tranche.decimals).toEqual(
             parseInt(trancheData.token.decimals, 10),
         );
@@ -58,7 +66,7 @@ describe('Tranche', () => {
 
     it('Fetches token', () => {
         const trancheData = getTrancheData();
-        const tranche = new Tranche(trancheData);
+        const tranche = new Tranche(trancheData, collateral);
         expect(tranche.token).toEqual(
             new Token(
                 1,
@@ -69,7 +77,7 @@ describe('Tranche', () => {
     });
 
     it('Fetches contract', () => {
-        const tranche = new Tranche(getTrancheData());
+        const tranche = new Tranche(getTrancheData(), collateral);
         expect(tranche.contract.address).toEqual(tranche.address);
         expect(tranche.contract instanceof Contract).toBeTruthy();
     });


### PR DESCRIPTION
This commit adds a function for tranche objects to get the expected
redeem value if the given tranche amount is redeemed for collateral