### PR TITLE
feat: add wrapper for univ2 amm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@buttonwood/sdk",
-    "version": "1.0.47",
+    "version": "1.0.49",
     "description": "Typescript SDK for the Buttonwood Protocol",
     "main": "./dist/src/index.js",
     "types": "./dist/src/index.d.ts",
@@ -28,6 +28,7 @@
         "@typescript-eslint/eslint-plugin": "^4.29.0",
         "@typescript-eslint/parser": "^4.29.0",
         "@uniswap/sdk-core": "^3.0.1",
+        "@uniswap/v2-sdk": "^3.0.1",
         "@uniswap/v3-sdk": "^3.3.2",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.3.0",

--- a/src/entities/amm/index.ts
+++ b/src/entities/amm/index.ts
@@ -1,0 +1,16 @@
+import { CurrencyAmount, Price, Token } from '@uniswap/sdk-core';
+
+export interface Amm {
+    token0: Token;
+    token1: Token;
+    token0Price: Price<Token, Token>;
+    token1Price: Price<Token, Token>;
+    getOutputAmount(
+        amountIn: CurrencyAmount<Token>,
+    ): Promise<[CurrencyAmount<Token>, Amm]>;
+    getInputAmount(
+        amountOut: CurrencyAmount<Token>,
+    ): Promise<[CurrencyAmount<Token>, Amm]>;
+}
+
+export * from './uniswapV2Pair';

--- a/src/entities/amm/uniswapV2Pair.ts
+++ b/src/entities/amm/uniswapV2Pair.ts
@@ -1,0 +1,43 @@
+import { Amm } from '.';
+import { Pair } from '@uniswap/v2-sdk';
+import { CurrencyAmount, Price, Token } from '@uniswap/sdk-core';
+
+/**
+ * Wraps the Uniswap V2 Pair class to properly implement the Am interface
+ */
+export class UniswapV2Pair implements Amm {
+    private pair: Pair;
+    public token0: Token;
+    public token1: Token;
+    public token0Price: Price<Token, Token>;
+    public token1Price: Price<Token, Token>;
+
+    constructor(
+        token0Amount: CurrencyAmount<Token>,
+        token1Amount: CurrencyAmount<Token>,
+    ) {
+        this.pair = new Pair(token0Amount, token1Amount);
+        this.token0 = this.pair.token0;
+        this.token1 = this.pair.token1;
+        this.token0Price = this.pair.token0Price;
+        this.token1Price = this.pair.token1Price;
+    }
+
+    public static fromPair(pair: Pair): UniswapV2Pair {
+        return new UniswapV2Pair(pair.reserve0, pair.reserve1);
+    }
+
+    public async getOutputAmount(
+        inputAmount: CurrencyAmount<Token>,
+    ): Promise<[CurrencyAmount<Token>, Amm]> {
+        const [amount, pair] = this.pair.getOutputAmount(inputAmount);
+        return [amount, UniswapV2Pair.fromPair(pair)];
+    }
+
+    public async getInputAmount(
+        outputAmount: CurrencyAmount<Token>,
+    ): Promise<[CurrencyAmount<Token>, Amm]> {
+        const [amount, pair] = this.pair.getInputAmount(outputAmount);
+        return [amount, UniswapV2Pair.fromPair(pair)];
+    }
+}

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -1,2 +1,3 @@
 export * from './bond';
 export * from './tranche';
+export * from './amm';

--- a/src/loanManager.ts
+++ b/src/loanManager.ts
@@ -3,6 +3,7 @@ import { BigNumber, constants } from 'ethers';
 import { Bond } from './entities/bond';
 import { CurrencyAmount, Price, Token } from '@uniswap/sdk-core';
 import { addressEquals, containsAddress } from './utils';
+import { Amm } from './entities/amm';
 
 export interface BorrowOutput {
     trancheTokens: CurrencyAmount<Token>[];
@@ -19,19 +20,6 @@ export interface BorrowInput {
 export interface GetSalesOptions {
     // true if we should format sales for contract input
     contractInput: boolean;
-}
-
-export interface Amm {
-    token0: Token;
-    token1: Token;
-    token0Price: Price<Token, Token>;
-    token1Price: Price<Token, Token>;
-    getOutputAmount(
-        amountIn: CurrencyAmount<Token>,
-    ): Promise<[CurrencyAmount<Token>, Amm]>;
-    getInputAmount(
-        amountOut: CurrencyAmount<Token>,
-    ): Promise<[CurrencyAmount<Token>, Amm]>;
 }
 
 export class LoanManager {

--- a/test/entities/amm/uniswapV2Pair.ts
+++ b/test/entities/amm/uniswapV2Pair.ts
@@ -1,0 +1,81 @@
+import { CurrencyAmount, Token } from '@uniswap/sdk-core';
+import { Pair } from '@uniswap/v2-sdk';
+import { UniswapV2Pair } from '../../../src';
+
+describe('UniswapV2Pair', () => {
+    const token0 = new Token(
+        1,
+        '0x2d27301821b05265a3f26bf6ad10745028791524',
+        18,
+        'TEST',
+        'test',
+    );
+
+    const token1 = new Token(
+        1,
+        '0x881d40237659c251811cec9c364ef91dc08d300c',
+        18,
+        'SQUANCH',
+        'squanch',
+    );
+
+    it('instantiates with normal pair parameters', () => {
+        const token0Amount = CurrencyAmount.fromRawAmount(token0, 500);
+        const token1Amount = CurrencyAmount.fromRawAmount(token1, 500);
+        const uniswapV2Pair = new UniswapV2Pair(token0Amount, token1Amount);
+        const pair = new Pair(token0Amount, token1Amount);
+
+        console.log(pair.token0);
+        console.log(pair.token1);
+        expect(uniswapV2Pair.token0.equals(pair.token0)).toBeTruthy();
+        expect(uniswapV2Pair.token1.equals(pair.token1)).toBeTruthy();
+    });
+
+    it('properly fetches prices', () => {
+        const token0Amount = CurrencyAmount.fromRawAmount(token0, 500);
+        const token1Amount = CurrencyAmount.fromRawAmount(token1, 500);
+        const uniswapV2Pair = new UniswapV2Pair(token0Amount, token1Amount);
+        const pair = new Pair(token0Amount, token1Amount);
+
+        expect(uniswapV2Pair.token0Price).toEqual(pair.token0Price);
+        expect(uniswapV2Pair.token1Price).toEqual(pair.token1Price);
+    });
+
+    it('properly instantiates from pair', () => {
+        const token0Amount = CurrencyAmount.fromRawAmount(token0, 500);
+        const token1Amount = CurrencyAmount.fromRawAmount(token1, 500);
+        const pair = new Pair(token0Amount, token1Amount);
+        const uniswapV2Pair = UniswapV2Pair.fromPair(pair);
+
+        expect(uniswapV2Pair.token0Price).toEqual(pair.token0Price);
+        expect(uniswapV2Pair.token1Price).toEqual(pair.token1Price);
+    });
+
+    it('gets output amount', async () => {
+        const token0Amount = CurrencyAmount.fromRawAmount(token0, 500);
+        const token1Amount = CurrencyAmount.fromRawAmount(token1, 500);
+        const pair = new Pair(token0Amount, token1Amount);
+        const uniswapV2Pair = UniswapV2Pair.fromPair(pair);
+
+        const amountIn = CurrencyAmount.fromRawAmount(token0, 5);
+        expect(
+            pair
+                .getOutputAmount(amountIn)[0]
+                .equalTo((await uniswapV2Pair.getOutputAmount(amountIn))[0]),
+        ).toBeTruthy();
+    });
+
+    it('gets input amount', async () => {
+        const token0Amount = CurrencyAmount.fromRawAmount(token0, 500);
+        const token1Amount = CurrencyAmount.fromRawAmount(token1, 500);
+        const pair = new Pair(token0Amount, token1Amount);
+        const uniswapV2Pair = UniswapV2Pair.fromPair(pair);
+
+        const amountOut = CurrencyAmount.fromRawAmount(token0, 5);
+        expect(
+            pair
+                .getInputAmount(amountOut)[0]
+                .equalTo((await uniswapV2Pair.getInputAmount(amountOut))[0]),
+        ).toBeTruthy();
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -386,6 +386,17 @@
     "@ethersproject/logger" "^5.4.0"
     "@ethersproject/rlp" "^5.4.0"
 
+"@ethersproject/address@^5.0.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.5.0.tgz#bcc6f576a553f21f3dd7ba17248f81b473c9c78f"
+  integrity sha512-l4Nj0eWlTUh6ro5IbPTgbpT4wRbdH5l8CQf7icF7sb/SI3Nhd9Y9HzhonTSTi6CefI0necIw7LJqQPopPLZyWw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/keccak256" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/rlp" "^5.5.0"
+
 "@ethersproject/base64@5.4.0", "@ethersproject/base64@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.4.0.tgz#7252bf65295954c9048c7ca5f43e5c86441b2a9a"
@@ -410,6 +421,15 @@
     "@ethersproject/logger" "^5.4.0"
     bn.js "^4.11.9"
 
+"@ethersproject/bignumber@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.5.0.tgz#875b143f04a216f4f8b96245bde942d42d279527"
+  integrity sha512-6Xytlwvy6Rn3U3gKEc1vP7nR92frHkv6wtVr95LFR3jREXiCPzdWxKQ1cx4JGQBXxcguAwjA8murlYN2TSiEbg==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    bn.js "^4.11.9"
+
 "@ethersproject/bytes@5.4.0", "@ethersproject/bytes@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.4.0.tgz#56fa32ce3bf67153756dbaefda921d1d4774404e"
@@ -417,12 +437,26 @@
   dependencies:
     "@ethersproject/logger" "^5.4.0"
 
+"@ethersproject/bytes@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.5.0.tgz#cb11c526de657e7b45d2e0f0246fb3b9d29a601c"
+  integrity sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==
+  dependencies:
+    "@ethersproject/logger" "^5.5.0"
+
 "@ethersproject/constants@5.4.0", "@ethersproject/constants@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.4.0.tgz#ee0bdcb30bf1b532d2353c977bf2ef1ee117958a"
   integrity sha512-tzjn6S7sj9+DIIeKTJLjK9WGN2Tj0P++Z8ONEIlZjyoTkBuODN+0VfhAyYksKi43l1Sx9tX2VlFfzjfmr5Wl3Q==
   dependencies:
     "@ethersproject/bignumber" "^5.4.0"
+
+"@ethersproject/constants@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.5.0.tgz#d2a2cd7d94bd1d58377d1d66c4f53c9be4d0a45e"
+  integrity sha512-2MsRRVChkvMWR+GyMGY4N1sAX9Mt3J9KykCsgUFd/1mwS0UH1qw+Bv9k1UJb3X3YJYFco9H20pjSlOIfCG5HYQ==
+  dependencies:
+    "@ethersproject/bignumber" "^5.5.0"
 
 "@ethersproject/contracts@5.4.1":
   version "5.4.1"
@@ -499,10 +533,23 @@
     "@ethersproject/bytes" "^5.4.0"
     js-sha3 "0.5.7"
 
+"@ethersproject/keccak256@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.5.0.tgz#e4b1f9d7701da87c564ffe336f86dcee82983492"
+  integrity sha512-5VoFCTjo2rYbBe1l2f4mccaRFN/4VQEYFwwn04aJV2h7qf4ZvI2wFxUE1XOX+snbwCLRzIeikOqtAoPwMza9kg==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    js-sha3 "0.8.0"
+
 "@ethersproject/logger@5.4.1", "@ethersproject/logger@^5.4.0":
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.4.1.tgz#503bd33683538b923c578c07d1c2c0dd18672054"
   integrity sha512-DZ+bRinnYLPw1yAC64oRl0QyVZj43QeHIhVKfD/+YwSz4wsv1pfwb5SOFjz+r710YEWzU6LrhuSjpSO+6PeE4A==
+
+"@ethersproject/logger@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.5.0.tgz#0c2caebeff98e10aefa5aef27d7441c7fd18cf5d"
+  integrity sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg==
 
 "@ethersproject/networks@5.4.2", "@ethersproject/networks@^5.4.0":
   version "5.4.2"
@@ -567,6 +614,14 @@
     "@ethersproject/bytes" "^5.4.0"
     "@ethersproject/logger" "^5.4.0"
 
+"@ethersproject/rlp@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.5.0.tgz#530f4f608f9ca9d4f89c24ab95db58ab56ab99a0"
+  integrity sha512-hLv8XaQ8PTI9g2RHoQGf/WSxBfTB/NudRacbzdxmst5VHAqd1sMibWG7SENzT5Dj3yZ3kJYx+WiRYEcQTAkcYA==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+
 "@ethersproject/sha2@5.4.0", "@ethersproject/sha2@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.4.0.tgz#c9a8db1037014cbc4e9482bd662f86c090440371"
@@ -574,6 +629,15 @@
   dependencies:
     "@ethersproject/bytes" "^5.4.0"
     "@ethersproject/logger" "^5.4.0"
+    hash.js "1.1.7"
+
+"@ethersproject/sha2@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.5.0.tgz#a40a054c61f98fd9eee99af2c3cc6ff57ec24db7"
+  integrity sha512-B5UBoglbCiHamRVPLA110J+2uqsifpZaTmid2/7W5rbtYVz6gus6/hSDieIU/6gaKIDcOj12WnOdiymEUHIAOA==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
     hash.js "1.1.7"
 
 "@ethersproject/signing-key@5.4.0", "@ethersproject/signing-key@^5.4.0":
@@ -599,6 +663,18 @@
     "@ethersproject/sha2" "^5.4.0"
     "@ethersproject/strings" "^5.4.0"
 
+"@ethersproject/solidity@^5.0.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.5.0.tgz#2662eb3e5da471b85a20531e420054278362f93f"
+  integrity sha512-9NgZs9LhGMj6aCtHXhtmFQ4AN4sth5HuFXVvAQtzmm0jpSCNOTGtrHZJAeYTh7MBjRR8brylWZxBZR9zDStXbw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/keccak256" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/sha2" "^5.5.0"
+    "@ethersproject/strings" "^5.5.0"
+
 "@ethersproject/strings@5.4.0", "@ethersproject/strings@^5.4.0":
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.4.0.tgz#fb12270132dd84b02906a8d895ae7e7fa3d07d9a"
@@ -607,6 +683,15 @@
     "@ethersproject/bytes" "^5.4.0"
     "@ethersproject/constants" "^5.4.0"
     "@ethersproject/logger" "^5.4.0"
+
+"@ethersproject/strings@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.5.0.tgz#e6784d00ec6c57710755699003bc747e98c5d549"
+  integrity sha512-9fy3TtF5LrX/wTrBaT8FGE6TDJyVjOvXynXJz5MT5azq+E6D92zuKNx7i29sWW2FjVOaWjAsiZ1ZWznuduTIIQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/constants" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
 
 "@ethersproject/transactions@5.4.0", "@ethersproject/transactions@^5.4.0":
   version "5.4.0"
@@ -1130,7 +1215,7 @@
   resolved "https://registry.yarnpkg.com/@uniswap/lib/-/lib-4.0.1-alpha.tgz#2881008e55f075344675b3bca93f020b028fbd02"
   integrity sha512-f6UIliwBbRsgVLxIaBANF6w09tYqc6Y/qXdsrbEmXHyFA7ILiKrIwRFXe1yOg8M3cksgVsO9N7yuL2DdCGQKBA==
 
-"@uniswap/sdk-core@^3.0.1":
+"@uniswap/sdk-core@^3.0.0-alpha.3", "@uniswap/sdk-core@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@uniswap/sdk-core/-/sdk-core-3.0.1.tgz#d08dd68257983af64b9a5f4d6b9cf26124b4138f"
   integrity sha512-WbeDkhZ9myVR0VnHOdTrb8nHKKkqTFa5uE9RvUbG3eyDt2NWWDwhhqGHwAWJEHG405l30Fa1u3PogHDFsIOQlA==
@@ -1146,6 +1231,17 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@uniswap/v2-core/-/v2-core-1.0.1.tgz#af8f508bf183204779938969e2e54043e147d425"
   integrity sha512-MtybtkUPSyysqLY2U210NBDeCHX+ltHt3oADGdjqoThZaFRDKwM6k1Nb3F0A3hk5hwuQvytFWhrWHOEq6nVJ8Q==
+
+"@uniswap/v2-sdk@^3.0.1":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@uniswap/v2-sdk/-/v2-sdk-3.0.1.tgz#690c484104c1debd1db56a236e5497def53d698b"
+  integrity sha512-eSpm2gjo2CZh9FACH5fq42str/oSNyWcDxB27o5k44bEew4sxb+pld4gGIf/byJndLBvArR9PtH8c0n/goNOTw==
+  dependencies:
+    "@ethersproject/address" "^5.0.0"
+    "@ethersproject/solidity" "^5.0.0"
+    "@uniswap/sdk-core" "^3.0.0-alpha.3"
+    tiny-invariant "^1.1.0"
+    tiny-warning "^1.0.3"
 
 "@uniswap/v3-core@1.0.0":
   version "1.0.0"
@@ -2830,6 +2926,11 @@ js-sha3@0.5.7:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.7.tgz#0d4ffd8002d5333aabaf4a23eed2f6374c9f28e7"
   integrity sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=
+
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
 
 js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
The Uniswap v2 library doesn't exactly match the AMM interface, so we
need to have our own wrapper class that composes the UniV2 entity logic
to match the interface. This way LoanManager will work happily with both
univ2 and univ3