### PR TITLE
fix: min collateral for borrow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@buttonwood/sdk",
-    "version": "1.0.50",
+    "version": "1.0.51",
     "description": "Typescript SDK for the Buttonwood Protocol",
     "main": "./dist/src/index.js",
     "types": "./dist/src/index.d.ts",

--- a/src/entities/bond.ts
+++ b/src/entities/bond.ts
@@ -223,9 +223,9 @@ export class Bond {
                         this.collateral,
                         toBaseUnits(desiredTrancheOutput)
                             .mul(TRANCHE_RATIO_GRANULARITY)
-                            .mul(this.totalCollateral)
+                            .mul(this.totalDebt)
                             .div(tranche.ratio)
-                            .div(this.totalDebt)
+                            .div(this.totalCollateral)
                             .toString(),
                     );
                 }


### PR DESCRIPTION
this commit fixes the calculation for minimum collateral on borrow.
Instead of always using the yTranche (i.e. B tranche in an ABZ bond), it
uses the tranche with the highest discount to calculate an estimation.
This should result in the estimation always being more than enough to
support the desired loan amount

It also fixes the getRequiredDeposit calculation to properly use dcr for
tranche ratio expansion rather than cdr