### PR TITLE
feat: fix collateral bounds estimation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@buttonwood/sdk",
-    "version": "1.0.53",
+    "version": "1.0.57",
     "description": "Typescript SDK for the Buttonwood Protocol",
     "main": "./dist/src/index.js",
     "types": "./dist/src/index.d.ts",

--- a/src/entities/bond.ts
+++ b/src/entities/bond.ts
@@ -236,11 +236,12 @@ export class Bond {
                 } else {
                     return CurrencyAmount.fromRawAmount(
                         this.collateral,
+                        // note this is the inverse of deposit calculation
                         toBaseUnits(desiredTrancheOutput)
                             .mul(TRANCHE_RATIO_GRANULARITY)
-                            .mul(this.totalDebt)
+                            .mul(this.totalCollateral)
                             .div(tranche.ratio)
-                            .div(this.totalCollateral)
+                            .div(this.totalDebt)
                             .toString(),
                     );
                 }


### PR DESCRIPTION
This commit fixes two major issues with the collateral bounds
estimation:
- getRequiredInput was returning incorrect values as it was using cdr
instead of dcr
- getMinimumCollateral was assuming roughly equivalent and uniform
liquidity and tick placement across the two pools (only using spot
price). We use a new binary search technique to handle this much more
acurately