### PR TITLE
feat: add tranche value calculation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@buttonwood/sdk",
-    "version": "1.0.57",
+    "version": "1.0.59",
     "description": "Typescript SDK for the Buttonwood Protocol",
     "main": "./dist/src/index.js",
     "types": "./dist/src/index.d.ts",


### PR DESCRIPTION
This commit adds a function to calculate the value of a tranche in terms
of collateral, even when it is immature