### PR TITLE
refactor: Updated loanManager functions to return Percent types

### DIFF
--- a/src/loanManager.ts
+++ b/src/loanManager.ts
@@ -125,7 +125,10 @@ export class LoanManager {
 
         // assuming tranche tokens can be sold for $1 later, how much USD will we make
         const expectedProfitUSD = expectedOutput.sub(depositValue);
-        return new Percent(expectedProfitUSD.toString(), depositValue.toString());
+        return new Percent(
+            expectedProfitUSD.toString(),
+            depositValue.toString(),
+        );
     }
 
     /**
@@ -217,7 +220,7 @@ export class LoanManager {
 
         invariant(
             runningOutput.greaterThan(desiredOutput) ||
-            runningOutput.equalTo(desiredOutput),
+                runningOutput.equalTo(desiredOutput),
             'Insufficient deposit',
         );
 
@@ -346,7 +349,7 @@ export class LoanManager {
         for (let i = 0; i < trancheAmounts.length - 1; i++) {
             invariant(
                 sales[i].lessThan(trancheAmounts[i]) ||
-                sales[i].equalTo(trancheAmounts[i]),
+                    sales[i].equalTo(trancheAmounts[i]),
                 'Invalid sale',
             );
             currencyOutput = currencyOutput.add(

--- a/src/loanManager.ts
+++ b/src/loanManager.ts
@@ -1,7 +1,7 @@
 import invariant from 'tiny-invariant';
-import { ethers, BigNumber, constants } from 'ethers';
+import { BigNumber, constants, ethers } from 'ethers';
 import { Bond } from './entities/bond';
-import { CurrencyAmount, Price, Token } from '@uniswap/sdk-core';
+import { CurrencyAmount, Percent, Price, Token } from '@uniswap/sdk-core';
 import { addressEquals, containsAddress } from './utils';
 import { Amm } from './entities/amm';
 
@@ -59,7 +59,7 @@ export class LoanManager {
      * @param sales The number of tranche tokens to sell, maybe output from `getSales`
      * @return discount The discount at which the user is getting currency from tranches
      */
-    async getDiscount(sales: CurrencyAmount<Token>[]): Promise<number> {
+    async getDiscount(sales: CurrencyAmount<Token>[]): Promise<Percent> {
         let totalAmountIn = BigNumber.from(0);
         let totalAmountOut = BigNumber.from(0);
         for (let i = 0; i < this.pools.length; i++) {
@@ -85,12 +85,9 @@ export class LoanManager {
 
         invariant(totalAmountOut.gt(0), 'No output');
 
-        return (
-            totalAmountIn
-                .sub(totalAmountOut)
-                .mul(100000)
-                .div(totalAmountOut)
-                .toNumber() / 100000
+        return new Percent(
+            totalAmountIn.sub(totalAmountOut).toString(),
+            totalAmountOut.toString(),
         );
     }
 
@@ -103,7 +100,7 @@ export class LoanManager {
     async getLenderInterest(
         deposit: CurrencyAmount<Token>,
         trancheIndex: number,
-    ): Promise<number> {
+    ): Promise<Percent> {
         const pool = this.pools[trancheIndex];
 
         // lender buys tranche tokens with cash
@@ -128,9 +125,7 @@ export class LoanManager {
 
         // assuming tranche tokens can be sold for $1 later, how much USD will we make
         const expectedProfitUSD = expectedOutput.sub(depositValue);
-        return (
-            expectedProfitUSD.mul(100000).div(depositValue).toNumber() / 1000
-        );
+        return new Percent(expectedProfitUSD.toString(), depositValue.toString());
     }
 
     /**
@@ -222,7 +217,7 @@ export class LoanManager {
 
         invariant(
             runningOutput.greaterThan(desiredOutput) ||
-                runningOutput.equalTo(desiredOutput),
+            runningOutput.equalTo(desiredOutput),
             'Insufficient deposit',
         );
 
@@ -351,7 +346,7 @@ export class LoanManager {
         for (let i = 0; i < trancheAmounts.length - 1; i++) {
             invariant(
                 sales[i].lessThan(trancheAmounts[i]) ||
-                    sales[i].equalTo(trancheAmounts[i]),
+                sales[i].equalTo(trancheAmounts[i]),
                 'Invalid sale',
             );
             currencyOutput = currencyOutput.add(

--- a/test/loanManager.ts
+++ b/test/loanManager.ts
@@ -1,6 +1,12 @@
 import { CurrencyAmount, Token } from '@uniswap/sdk-core';
 import { Bond, BondData, LoanManager, TrancheData } from '../src';
-import { encodeSqrtRatioX96, FeeAmount, nearestUsableTick, Pool, TickMath } from '@uniswap/v3-sdk';
+import {
+    encodeSqrtRatioX96,
+    FeeAmount,
+    nearestUsableTick,
+    Pool,
+    TickMath,
+} from '@uniswap/v3-sdk';
 
 function getTrancheData(
     address: string,

--- a/test/loanManager.ts
+++ b/test/loanManager.ts
@@ -1,12 +1,6 @@
 import { CurrencyAmount, Token } from '@uniswap/sdk-core';
 import { Bond, BondData, LoanManager, TrancheData } from '../src';
-import {
-    Pool,
-    TickMath,
-    nearestUsableTick,
-    FeeAmount,
-    encodeSqrtRatioX96,
-} from '@uniswap/v3-sdk';
+import { encodeSqrtRatioX96, FeeAmount, nearestUsableTick, Pool, TickMath } from '@uniswap/v3-sdk';
 
 function getTrancheData(
     address: string,
@@ -134,6 +128,6 @@ describe('LoanManager', () => {
             '50000000000',
         );
         const lenderAPY = await loanManager.getLenderInterest(deposit, 0);
-        expect(lenderAPY).toEqual(0.696);
+        expect(lenderAPY.toFixed(3)).toEqual('0.697');
     });
 });


### PR DESCRIPTION
Updated loanManager functions to return Percent types instead of numbers, to better preserve precision until point of rendering