### PR TITLE
feat: add tranche collateralization value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@buttonwood/sdk",
-    "version": "1.0.61",
+    "version": "1.0.66",
     "description": "Typescript SDK for the Buttonwood Protocol",
     "main": "./dist/src/index.js",
     "types": "./dist/src/index.d.ts",

--- a/test/entities/bond.ts
+++ b/test/entities/bond.ts
@@ -454,4 +454,70 @@ describe('Bond', () => {
             );
         });
     });
+
+    describe('Collateralization', () => {
+        it('successfully gets collateralization for A tranche', () => {
+            const bondData = getBondData({ totalCollateral: '3000000' });
+            const bond = new Bond(bondData);
+
+            const output = bond.collateralization(0);
+            expect(output.toFixed(0).toString()).toEqual('300');
+        });
+
+        it('successfully gets collateralization for B tranche', () => {
+            const bondData = getBondData({ totalCollateral: '3000000' });
+            const bond = new Bond(bondData);
+
+            const output = bond.collateralization(1);
+            expect(output.toFixed(0).toString()).toEqual('200');
+        });
+
+        it('successfully gets collateralization for Z tranche', () => {
+            const bondData = getBondData({ totalCollateral: '3000000' });
+            const bond = new Bond(bondData);
+
+            const output = bond.collateralization(2);
+            expect(output.toFixed(0).toString()).toEqual('100');
+        });
+
+        it('successfully gets collateralization for A tranche =100%', () => {
+            const bondData = getBondData({ totalCollateral: '1000000' });
+            const bond = new Bond(bondData);
+
+            const output = bond.collateralization(0);
+            expect(output.toFixed(0).toString()).toEqual('100');
+        });
+
+        it('successfully gets collateralization for A tranche <100%', () => {
+            const bondData = getBondData({ totalCollateral: '500000' });
+            const bond = new Bond(bondData);
+
+            const output = bond.collateralization(0);
+            expect(output.toFixed(0)).toEqual('50');
+        });
+
+        it('successfully gets collateralization for B tranche =100%', () => {
+            const bondData = getBondData({ totalCollateral: '2000000' });
+            const bond = new Bond(bondData);
+
+            const output = bond.collateralization(1);
+            expect(output.toFixed(0).toString()).toEqual('100');
+        });
+
+        it('successfully gets collateralization for B tranche <100%', () => {
+            const bondData = getBondData({ totalCollateral: '1500000' });
+            const bond = new Bond(bondData);
+
+            const output = bond.collateralization(1);
+            expect(output.toFixed(0)).toEqual('50');
+        });
+
+        it('successfully gets collateralization for B tranche 0%', () => {
+            const bondData = getBondData({ totalCollateral: '1000000' });
+            const bond = new Bond(bondData);
+
+            const output = bond.collateralization(1);
+            expect(output.toFixed(0)).toEqual('0');
+        });
+    });
 });


### PR DESCRIPTION
This commit adds a new figure for tranches which is more useful in
certain contexts than plain CDR. it's the collateralization of
a specific tranche, i.e. how much collateral is backing it -- where 100%
means it will be redeemed 1:1